### PR TITLE
Fix order by type not found if fullTextSearch enabled

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -655,13 +655,15 @@ export class SchemaBuilder {
 
     if (publisherConfig.ordering) {
       const orderByTypeName = `${field.outputType.type}OrderByInput`
-      const orderByTypeNamePreviewFeature = `${field.outputType.type}OrderByWithRelationInput`
+      const orderByWithRelationTypeName = `${field.outputType.type}OrderByWithRelationInput`
+      const orderByWithRelationAndSearchRelevanceTypeName = `${field.outputType.type}OrderByWithRelationAndSearchRelevanceInput`
       const orderByArg = field.args.find(
         (arg) =>
           (arg.inputType.type === orderByTypeName ||
-            arg.inputType.type === orderByTypeNamePreviewFeature) &&
+            arg.inputType.type === orderByWithRelationTypeName ||
+            arg.inputType.type === orderByWithRelationAndSearchRelevanceTypeName) &&
           arg.name === 'orderBy'
-      );
+      )
 
       if (!orderByArg) {
         throw new Error(`Could not find ordering argument for ${typeName}.${field.name}`)

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -21,7 +21,7 @@ export function resolveUniqueIdentifiers(typeName: string, dmmf: DmmfDocument): 
 
   // Try finding 2.
   if (model.primaryKey && model.primaryKey.fields.length > 0) {
-    return model.primaryKey.fields;
+    return model.primaryKey.fields
   }
 
   const singleUniqueField = model.fields.find((f) => f.isUnique)

--- a/src/dmmf/DmmfTypes.ts
+++ b/src/dmmf/DmmfTypes.ts
@@ -101,8 +101,8 @@ export declare namespace InternalDMMF {
   interface Mapping {
     model: string
     plural: string
-    aggregate?: string | null;
-    groupBy?: string | null;
+    aggregate?: string | null
+    groupBy?: string | null
     // findFirst?: string | null;
     findUnique?: string | null
     findMany?: string | null

--- a/src/dmmf/transformer.ts
+++ b/src/dmmf/transformer.ts
@@ -45,18 +45,13 @@ export function transform(
   options?: TransformOptions & OptionalTransformOptions
 ): InternalDMMF.Document {
   if (!options?.dmmfDocumentIncludesSchema) {
-    const cwd = process.cwd();
+    const cwd = process.cwd()
 
     if (!options?.prismaClientPackagePath?.trim()) {
       throw new Error('prismaClientPackagePath invalid')
     }
 
-    let datamodelPath = resolve(
-      cwd,
-      'node_modules',
-      options.prismaClientPackagePath,
-      'schema.prisma'
-    )
+    let datamodelPath = resolve(cwd, 'node_modules', options.prismaClientPackagePath, 'schema.prisma')
     if (!existsSync(datamodelPath)) {
       // 2nd chance
       datamodelPath = resolve(cwd, 'node_modules', '.prisma', 'client', 'schema.prisma')
@@ -69,9 +64,9 @@ export function transform(
 
       const datamodel = readFileSync(datamodelPath, { encoding: 'utf8' })
       // this is an async operation - thus the async-to-sync wrapper
-      const tmpFilePath = tmpdir();
+      const tmpFilePath = tmpdir()
 
-      const cwdNodeModules = resolve(cwd, 'node_modules').replace(/\\/g, '\\\\');
+      const cwdNodeModules = resolve(cwd, 'node_modules').replace(/\\/g, '\\\\')
 
       const getSchemaDocumentSync = runSync({
         code: `

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ function ensureDepIsInstalled(depName: string) {
   try {
     require(depName)
   } catch (rawErr) {
-    const err = rawErr as {code?: string};
+    const err = rawErr as { code?: string }
     if (err.code === 'MODULE_NOT_FOUND') {
       console.error(
         `${colors.red('ERROR:')} ${colors.green(

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -31,7 +31,7 @@ const buildField = (mapping: InternalDMMF.Mapping, operation: OperationName): Ba
 const CRUD_MAPPED_FIELDS: Record<string, (m: InternalDMMF.Mapping) => (BaseMappedField | null)[]> = {
   Query: (m) => [
     buildField(m, 'aggregate'),
-    // buildField(m, 'findFirst'), 
+    // buildField(m, 'findFirst'),
     buildField(m, 'findMany'),
     buildField(m, 'findUnique'),
     buildField(m, 'groupBy'),
@@ -53,16 +53,14 @@ export const getCrudMappedFields = (
   namingStrategy: FieldNamingStrategy = defaultFieldNamingStrategy
 ): MappedField[] => {
   const mappedFields = flatMap(dmmf.operations, (m) => {
-    const res = CRUD_MAPPED_FIELDS[typeName](m);
+    const res = CRUD_MAPPED_FIELDS[typeName](m)
     // appendFileSync('tmp.output.log.txt', `mapping::getCrudMappedFields() - [${typeName}][${JSON.stringify(m)}] as res=${JSON.stringify(res)}\n`);
-    return res;
-  }).filter(
-    (mappedField) => {
-      const res = mappedField !== null;
-      // appendFileSync('tmp.output.log.txt', `mapping::getCrudMappedFields() - [${typeName}] field ${JSON.stringify(mappedField)} - res=${res}\n`);
-      return res;
-    }
-  ) as BaseMappedField[]
+    return res
+  }).filter((mappedField) => {
+    const res = mappedField !== null
+    // appendFileSync('tmp.output.log.txt', `mapping::getCrudMappedFields() - [${typeName}] field ${JSON.stringify(mappedField)} - res=${res}\n`);
+    return res
+  }) as BaseMappedField[]
 
   const result = mappedFields.map((mappedField) => ({
     ...mappedField,

--- a/src/typegen/static.ts
+++ b/src/typegen/static.ts
@@ -170,7 +170,7 @@ export type BaseRelationOptions<
   resolve?: CustomFieldResolver<TypeName, Alias extends undefined ? MethodName : Alias>
   computedInputs?: LocalComputedInputs<MethodName>
 } & NexusGenPluginFieldConfig<TypeName, Alias extends undefined ? MethodName : Alias> &
-CommonFieldConfig
+  CommonFieldConfig
 
 // If GetNexusPrismaInput returns never, it means there are no filtering/ordering args for it.
 type NexusPrismaRelationOpts<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,7 +47,7 @@ export const hardWriteFileSync = (filePath: string, data: string): void => {
   try {
     fs.remove(filePath)
   } catch (error) {
-    if ((error as {code?: string}).code !== 'ENOENT') throw error
+    if ((error as { code?: string }).code !== 'ENOENT') throw error
   }
   fs.write(filePath, data)
 }
@@ -187,20 +187,20 @@ export function apply<T, F extends Function = (x: T) => any>(val: T, fn: F): any
 
 export async function delay(milliseconds: number) {
   return new Promise<void>((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
+    setTimeout(resolve, milliseconds)
+  })
 }
 
 export async function tryDelete(path: string, numberRetries = 1): Promise<void> {
-  let retryIndex = 0;
-  while(retryIndex < numberRetries) {
+  let retryIndex = 0
+  while (retryIndex < numberRetries) {
     try {
-      await fs.removeAsync(path);
-      break;
-    } catch(e) {
+      await fs.removeAsync(path)
+      break
+    } catch (e) {
       // swallow
-      retryIndex += 1;
-      await delay(250);
+      retryIndex += 1
+      await delay(250)
     }
   }
 }

--- a/src/utilsSync.ts
+++ b/src/utilsSync.ts
@@ -57,7 +57,7 @@ export function runSync(params: {
     const tmpFile = resolve(tmpFilePath, `tmp${Date.now()}_${randomUUID()}.js`)
 
     writeFileSync(tmpFile, codeString, 'utf8')
-    let rawOutput = '';
+    let rawOutput = ''
 
     try {
       rawOutput = execSync(`${nodeExecutable} ${tmpFile}`, { maxBuffer: maxBufferSize, cwd }).toString()

--- a/tests/__app/generated/nexus-plugin-prisma-typegen.d.ts
+++ b/tests/__app/generated/nexus-plugin-prisma-typegen.d.ts
@@ -1,12 +1,12 @@
 import * as Typegen from '../../../src/typegen/static'
-import * as Prisma from '@prisma/client';
+import * as Prisma from '@prisma/client'
 
 // Pagination type
 type Pagination = {
-    first?: boolean
-    last?: boolean
-    before?: boolean
-    after?: boolean
+  first?: boolean
+  last?: boolean
+  before?: boolean
+  after?: boolean
 }
 
 // Prisma custom scalar names
@@ -32,12 +32,44 @@ interface NexusPrismaInputs {
       ordering: 'id' | 'createdAt' | 'private' | '_count' | '_max' | '_min'
     }
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'firstName'
+        | 'lastName'
+        | 'bubbleId'
+        | 'locationId'
+        | 'posts'
+        | 'location'
+        | 'Bubble'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
     }
     groupByUser: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
-      ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | '_count' | '_avg' | '_max' | '_min' | '_sum'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'firstName'
+        | 'lastName'
+        | 'bubbleId'
+        | 'locationId'
+        | 'posts'
+        | 'location'
+        | 'Bubble'
+      ordering:
+        | 'id'
+        | 'firstName'
+        | 'lastName'
+        | 'bubbleId'
+        | 'locationId'
+        | '_count'
+        | '_avg'
+        | '_max'
+        | '_min'
+        | '_sum'
     }
     locations: {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'country' | 'city' | 'User'
@@ -55,10 +87,21 @@ interface NexusPrismaInputs {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'rating' | 'likes' | 'status' | 'authors'
       ordering: 'id' | 'rating' | 'likes' | 'status' | '_count' | '_avg' | '_max' | '_min' | '_sum'
     }
-  },
+  }
   Bubble: {
     members: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'firstName'
+        | 'lastName'
+        | 'bubbleId'
+        | 'locationId'
+        | 'posts'
+        | 'location'
+        | 'Bubble'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
     }
   }
@@ -70,13 +113,35 @@ interface NexusPrismaInputs {
   }
   Location: {
     User: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'firstName'
+        | 'lastName'
+        | 'bubbleId'
+        | 'locationId'
+        | 'posts'
+        | 'location'
+        | 'Bubble'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
     }
   }
   Post: {
     authors: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
+      filtering:
+        | 'AND'
+        | 'OR'
+        | 'NOT'
+        | 'id'
+        | 'firstName'
+        | 'lastName'
+        | 'bubbleId'
+        | 'locationId'
+        | 'posts'
+        | 'location'
+        | 'Bubble'
       ordering: 'id' | 'firstName' | 'lastName' | 'bubbleId' | 'locationId' | 'posts' | 'location' | 'Bubble'
     }
   }
@@ -101,7 +166,7 @@ interface NexusPrismaOutputs {
     posts: 'Post'
     post: 'Post'
     groupByPost: 'PostGroupByOutputType'
-  },
+  }
   Mutation: {
     createOneBubble: 'Bubble'
     createManyBubble: 'AffectedRowsOutput'
@@ -131,7 +196,7 @@ interface NexusPrismaOutputs {
     updateOnePost: 'Post'
     updateManyPost: 'AffectedRowsOutput'
     upsertOnePost: 'Post'
-  },
+  }
   Bubble: {
     id: 'String'
     createdAt: 'DateTime'
@@ -185,9 +250,8 @@ interface NexusPrismaGenTypes {
 declare global {
   interface NexusPrismaGen extends NexusPrismaGenTypes {}
 
-  type NexusPrisma<
-    TypeName extends string,
-    ModelOrCrud extends 'model' | 'crud'
-  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+  type NexusPrisma<TypeName extends string, ModelOrCrud extends 'model' | 'crud'> = Typegen.GetNexusPrisma<
+    TypeName,
+    ModelOrCrud
+  >
 }
-  

--- a/tests/__app/generated/nexus-typegen.d.ts
+++ b/tests/__app/generated/nexus-typegen.d.ts
@@ -3,10 +3,6 @@
  * Do not make changes to this file directly
  */
 
-
-
-
-
 declare global {
   interface NexusGenCustomOutputProperties<TypeName extends string> {
     crud: NexusPrisma<TypeName, 'crud'>
@@ -19,298 +15,340 @@ declare global {
 }
 
 export interface NexusGenInputs {
-  BoolFilter: { // input type
-    equals?: boolean | null; // Boolean
-    not?: NexusGenInputs['NestedBoolFilter'] | null; // NestedBoolFilter
+  BoolFilter: {
+    // input type
+    equals?: boolean | null // Boolean
+    not?: NexusGenInputs['NestedBoolFilter'] | null // NestedBoolFilter
   }
-  BubbleCreateNestedOneWithoutMembersInput: { // input type
-    connect?: NexusGenInputs['BubbleWhereUniqueInput'] | null; // BubbleWhereUniqueInput
-    connectOrCreate?: NexusGenInputs['BubbleCreateOrConnectWithoutMembersInput'] | null; // BubbleCreateOrConnectWithoutMembersInput
-    create?: NexusGenInputs['BubbleCreateWithoutMembersInput'] | null; // BubbleCreateWithoutMembersInput
+  BubbleCreateNestedOneWithoutMembersInput: {
+    // input type
+    connect?: NexusGenInputs['BubbleWhereUniqueInput'] | null // BubbleWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['BubbleCreateOrConnectWithoutMembersInput'] | null // BubbleCreateOrConnectWithoutMembersInput
+    create?: NexusGenInputs['BubbleCreateWithoutMembersInput'] | null // BubbleCreateWithoutMembersInput
   }
-  BubbleCreateOrConnectWithoutMembersInput: { // input type
-    create: NexusGenInputs['BubbleCreateWithoutMembersInput']; // BubbleCreateWithoutMembersInput!
-    where: NexusGenInputs['BubbleWhereUniqueInput']; // BubbleWhereUniqueInput!
+  BubbleCreateOrConnectWithoutMembersInput: {
+    // input type
+    create: NexusGenInputs['BubbleCreateWithoutMembersInput'] // BubbleCreateWithoutMembersInput!
+    where: NexusGenInputs['BubbleWhereUniqueInput'] // BubbleWhereUniqueInput!
   }
-  BubbleCreateWithoutMembersInput: { // input type
-    createdAt?: NexusGenScalars['DateTime'] | null; // DateTime
-    id?: string | null; // String
-    private: boolean; // Boolean!
+  BubbleCreateWithoutMembersInput: {
+    // input type
+    createdAt?: NexusGenScalars['DateTime'] | null // DateTime
+    id?: string | null // String
+    private: boolean // Boolean!
   }
-  BubbleMembersOrderByInput: { // input type
-    firstName?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    locationId?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  BubbleMembersOrderByInput: {
+    // input type
+    firstName?: NexusGenEnums['SortOrder'] | null // SortOrder
+    locationId?: NexusGenEnums['SortOrder'] | null // SortOrder
   }
-  BubbleMembersWhereInput: { // input type
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    location?: NexusGenInputs['LocationWhereInput'] | null; // LocationWhereInput
+  BubbleMembersWhereInput: {
+    // input type
+    id?: NexusGenInputs['StringFilter'] | null // StringFilter
+    location?: NexusGenInputs['LocationWhereInput'] | null // LocationWhereInput
   }
-  BubbleWhereInput: { // input type
-    AND?: NexusGenInputs['BubbleWhereInput'][] | null; // [BubbleWhereInput!]
-    NOT?: NexusGenInputs['BubbleWhereInput'][] | null; // [BubbleWhereInput!]
-    OR?: NexusGenInputs['BubbleWhereInput'][] | null; // [BubbleWhereInput!]
-    createdAt?: NexusGenInputs['DateTimeFilter'] | null; // DateTimeFilter
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    members?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
-    private?: NexusGenInputs['BoolFilter'] | null; // BoolFilter
+  BubbleWhereInput: {
+    // input type
+    AND?: NexusGenInputs['BubbleWhereInput'][] | null // [BubbleWhereInput!]
+    NOT?: NexusGenInputs['BubbleWhereInput'][] | null // [BubbleWhereInput!]
+    OR?: NexusGenInputs['BubbleWhereInput'][] | null // [BubbleWhereInput!]
+    createdAt?: NexusGenInputs['DateTimeFilter'] | null // DateTimeFilter
+    id?: NexusGenInputs['StringFilter'] | null // StringFilter
+    members?: NexusGenInputs['UserListRelationFilter'] | null // UserListRelationFilter
+    private?: NexusGenInputs['BoolFilter'] | null // BoolFilter
   }
-  BubbleWhereUniqueInput: { // input type
-    id?: string | null; // String
+  BubbleWhereUniqueInput: {
+    // input type
+    id?: string | null // String
   }
-  DateTimeFilter: { // input type
-    equals?: NexusGenScalars['DateTime'] | null; // DateTime
-    gt?: NexusGenScalars['DateTime'] | null; // DateTime
-    gte?: NexusGenScalars['DateTime'] | null; // DateTime
-    in?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
-    lt?: NexusGenScalars['DateTime'] | null; // DateTime
-    lte?: NexusGenScalars['DateTime'] | null; // DateTime
-    not?: NexusGenInputs['NestedDateTimeFilter'] | null; // NestedDateTimeFilter
-    notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
+  DateTimeFilter: {
+    // input type
+    equals?: NexusGenScalars['DateTime'] | null // DateTime
+    gt?: NexusGenScalars['DateTime'] | null // DateTime
+    gte?: NexusGenScalars['DateTime'] | null // DateTime
+    in?: NexusGenScalars['DateTime'][] | null // [DateTime!]
+    lt?: NexusGenScalars['DateTime'] | null // DateTime
+    lte?: NexusGenScalars['DateTime'] | null // DateTime
+    not?: NexusGenInputs['NestedDateTimeFilter'] | null // NestedDateTimeFilter
+    notIn?: NexusGenScalars['DateTime'][] | null // [DateTime!]
   }
-  EnumPostStatusFieldUpdateOperationsInput: { // input type
-    set?: NexusGenEnums['PostStatus'] | null; // PostStatus
+  EnumPostStatusFieldUpdateOperationsInput: {
+    // input type
+    set?: NexusGenEnums['PostStatus'] | null // PostStatus
   }
-  EnumPostStatusFilter: { // input type
-    equals?: NexusGenEnums['PostStatus'] | null; // PostStatus
-    in?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
-    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null; // NestedEnumPostStatusFilter
-    notIn?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
+  EnumPostStatusFilter: {
+    // input type
+    equals?: NexusGenEnums['PostStatus'] | null // PostStatus
+    in?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
+    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null // NestedEnumPostStatusFilter
+    notIn?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
   }
-  FloatFieldUpdateOperationsInput: { // input type
-    decrement?: number | null; // Float
-    divide?: number | null; // Float
-    increment?: number | null; // Float
-    multiply?: number | null; // Float
-    set?: number | null; // Float
+  FloatFieldUpdateOperationsInput: {
+    // input type
+    decrement?: number | null // Float
+    divide?: number | null // Float
+    increment?: number | null // Float
+    multiply?: number | null // Float
+    set?: number | null // Float
   }
-  FloatFilter: { // input type
-    equals?: number | null; // Float
-    gt?: number | null; // Float
-    gte?: number | null; // Float
-    in?: number[] | null; // [Float!]
-    lt?: number | null; // Float
-    lte?: number | null; // Float
-    not?: NexusGenInputs['NestedFloatFilter'] | null; // NestedFloatFilter
-    notIn?: number[] | null; // [Float!]
+  FloatFilter: {
+    // input type
+    equals?: number | null // Float
+    gt?: number | null // Float
+    gte?: number | null // Float
+    in?: number[] | null // [Float!]
+    lt?: number | null // Float
+    lte?: number | null // Float
+    not?: NexusGenInputs['NestedFloatFilter'] | null // NestedFloatFilter
+    notIn?: number[] | null // [Float!]
   }
-  IntFieldUpdateOperationsInput: { // input type
-    decrement?: number | null; // Int
-    divide?: number | null; // Int
-    increment?: number | null; // Int
-    multiply?: number | null; // Int
-    set?: number | null; // Int
+  IntFieldUpdateOperationsInput: {
+    // input type
+    decrement?: number | null // Int
+    divide?: number | null // Int
+    increment?: number | null // Int
+    multiply?: number | null // Int
+    set?: number | null // Int
   }
-  IntFilter: { // input type
-    equals?: number | null; // Int
-    gt?: number | null; // Int
-    gte?: number | null; // Int
-    in?: number[] | null; // [Int!]
-    lt?: number | null; // Int
-    lte?: number | null; // Int
-    not?: NexusGenInputs['NestedIntFilter'] | null; // NestedIntFilter
-    notIn?: number[] | null; // [Int!]
+  IntFilter: {
+    // input type
+    equals?: number | null // Int
+    gt?: number | null // Int
+    gte?: number | null // Int
+    in?: number[] | null // [Int!]
+    lt?: number | null // Int
+    lte?: number | null // Int
+    not?: NexusGenInputs['NestedIntFilter'] | null // NestedIntFilter
+    notIn?: number[] | null // [Int!]
   }
-  LocationCreateNestedOneWithoutUserInput: { // input type
-    connect?: NexusGenInputs['LocationWhereUniqueInput'] | null; // LocationWhereUniqueInput
-    connectOrCreate?: NexusGenInputs['LocationCreateOrConnectWithoutUserInput'] | null; // LocationCreateOrConnectWithoutUserInput
-    create?: NexusGenInputs['LocationCreateWithoutUserInput'] | null; // LocationCreateWithoutUserInput
+  LocationCreateNestedOneWithoutUserInput: {
+    // input type
+    connect?: NexusGenInputs['LocationWhereUniqueInput'] | null // LocationWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['LocationCreateOrConnectWithoutUserInput'] | null // LocationCreateOrConnectWithoutUserInput
+    create?: NexusGenInputs['LocationCreateWithoutUserInput'] | null // LocationCreateWithoutUserInput
   }
-  LocationCreateOrConnectWithoutUserInput: { // input type
-    create: NexusGenInputs['LocationCreateWithoutUserInput']; // LocationCreateWithoutUserInput!
-    where: NexusGenInputs['LocationWhereUniqueInput']; // LocationWhereUniqueInput!
+  LocationCreateOrConnectWithoutUserInput: {
+    // input type
+    create: NexusGenInputs['LocationCreateWithoutUserInput'] // LocationCreateWithoutUserInput!
+    where: NexusGenInputs['LocationWhereUniqueInput'] // LocationWhereUniqueInput!
   }
-  LocationCreateWithoutUserInput: { // input type
-    city: string; // String!
-    country: string; // String!
+  LocationCreateWithoutUserInput: {
+    // input type
+    city: string // String!
+    country: string // String!
   }
-  LocationWhereInput: { // input type
-    AND?: NexusGenInputs['LocationWhereInput'][] | null; // [LocationWhereInput!]
-    NOT?: NexusGenInputs['LocationWhereInput'][] | null; // [LocationWhereInput!]
-    OR?: NexusGenInputs['LocationWhereInput'][] | null; // [LocationWhereInput!]
-    User?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
-    city?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    country?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    id?: NexusGenInputs['IntFilter'] | null; // IntFilter
+  LocationWhereInput: {
+    // input type
+    AND?: NexusGenInputs['LocationWhereInput'][] | null // [LocationWhereInput!]
+    NOT?: NexusGenInputs['LocationWhereInput'][] | null // [LocationWhereInput!]
+    OR?: NexusGenInputs['LocationWhereInput'][] | null // [LocationWhereInput!]
+    User?: NexusGenInputs['UserListRelationFilter'] | null // UserListRelationFilter
+    city?: NexusGenInputs['StringFilter'] | null // StringFilter
+    country?: NexusGenInputs['StringFilter'] | null // StringFilter
+    id?: NexusGenInputs['IntFilter'] | null // IntFilter
   }
-  LocationWhereUniqueInput: { // input type
-    id?: number | null; // Int
+  LocationWhereUniqueInput: {
+    // input type
+    id?: number | null // Int
   }
-  NestedBoolFilter: { // input type
-    equals?: boolean | null; // Boolean
-    not?: NexusGenInputs['NestedBoolFilter'] | null; // NestedBoolFilter
+  NestedBoolFilter: {
+    // input type
+    equals?: boolean | null // Boolean
+    not?: NexusGenInputs['NestedBoolFilter'] | null // NestedBoolFilter
   }
-  NestedDateTimeFilter: { // input type
-    equals?: NexusGenScalars['DateTime'] | null; // DateTime
-    gt?: NexusGenScalars['DateTime'] | null; // DateTime
-    gte?: NexusGenScalars['DateTime'] | null; // DateTime
-    in?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
-    lt?: NexusGenScalars['DateTime'] | null; // DateTime
-    lte?: NexusGenScalars['DateTime'] | null; // DateTime
-    not?: NexusGenInputs['NestedDateTimeFilter'] | null; // NestedDateTimeFilter
-    notIn?: NexusGenScalars['DateTime'][] | null; // [DateTime!]
+  NestedDateTimeFilter: {
+    // input type
+    equals?: NexusGenScalars['DateTime'] | null // DateTime
+    gt?: NexusGenScalars['DateTime'] | null // DateTime
+    gte?: NexusGenScalars['DateTime'] | null // DateTime
+    in?: NexusGenScalars['DateTime'][] | null // [DateTime!]
+    lt?: NexusGenScalars['DateTime'] | null // DateTime
+    lte?: NexusGenScalars['DateTime'] | null // DateTime
+    not?: NexusGenInputs['NestedDateTimeFilter'] | null // NestedDateTimeFilter
+    notIn?: NexusGenScalars['DateTime'][] | null // [DateTime!]
   }
-  NestedEnumPostStatusFilter: { // input type
-    equals?: NexusGenEnums['PostStatus'] | null; // PostStatus
-    in?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
-    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null; // NestedEnumPostStatusFilter
-    notIn?: NexusGenEnums['PostStatus'][] | null; // [PostStatus!]
+  NestedEnumPostStatusFilter: {
+    // input type
+    equals?: NexusGenEnums['PostStatus'] | null // PostStatus
+    in?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
+    not?: NexusGenInputs['NestedEnumPostStatusFilter'] | null // NestedEnumPostStatusFilter
+    notIn?: NexusGenEnums['PostStatus'][] | null // [PostStatus!]
   }
-  NestedFloatFilter: { // input type
-    equals?: number | null; // Float
-    gt?: number | null; // Float
-    gte?: number | null; // Float
-    in?: number[] | null; // [Float!]
-    lt?: number | null; // Float
-    lte?: number | null; // Float
-    not?: NexusGenInputs['NestedFloatFilter'] | null; // NestedFloatFilter
-    notIn?: number[] | null; // [Float!]
+  NestedFloatFilter: {
+    // input type
+    equals?: number | null // Float
+    gt?: number | null // Float
+    gte?: number | null // Float
+    in?: number[] | null // [Float!]
+    lt?: number | null // Float
+    lte?: number | null // Float
+    not?: NexusGenInputs['NestedFloatFilter'] | null // NestedFloatFilter
+    notIn?: number[] | null // [Float!]
   }
-  NestedIntFilter: { // input type
-    equals?: number | null; // Int
-    gt?: number | null; // Int
-    gte?: number | null; // Int
-    in?: number[] | null; // [Int!]
-    lt?: number | null; // Int
-    lte?: number | null; // Int
-    not?: NexusGenInputs['NestedIntFilter'] | null; // NestedIntFilter
-    notIn?: number[] | null; // [Int!]
+  NestedIntFilter: {
+    // input type
+    equals?: number | null // Int
+    gt?: number | null // Int
+    gte?: number | null // Int
+    in?: number[] | null // [Int!]
+    lt?: number | null // Int
+    lte?: number | null // Int
+    not?: NexusGenInputs['NestedIntFilter'] | null // NestedIntFilter
+    notIn?: number[] | null // [Int!]
   }
-  NestedStringFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    not?: NexusGenInputs['NestedStringFilter'] | null; // NestedStringFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  NestedStringFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    not?: NexusGenInputs['NestedStringFilter'] | null // NestedStringFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  NestedStringNullableFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    not?: NexusGenInputs['NestedStringNullableFilter'] | null; // NestedStringNullableFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  NestedStringNullableFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    not?: NexusGenInputs['NestedStringNullableFilter'] | null // NestedStringNullableFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  PostCreateInput: { // input type
-    authors?: NexusGenInputs['UserCreateNestedManyWithoutPostsInput'] | null; // UserCreateNestedManyWithoutPostsInput
-    likes: number; // Int!
-    rating: number; // Float!
-    status: NexusGenEnums['PostStatus']; // PostStatus!
+  PostCreateInput: {
+    // input type
+    authors?: NexusGenInputs['UserCreateNestedManyWithoutPostsInput'] | null // UserCreateNestedManyWithoutPostsInput
+    likes: number // Int!
+    rating: number // Float!
+    status: NexusGenEnums['PostStatus'] // PostStatus!
   }
-  PostListRelationFilter: { // input type
-    every?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
-    none?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
-    some?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
+  PostListRelationFilter: {
+    // input type
+    every?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
+    none?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
+    some?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
   }
-  PostOrderByWithRelationInput: { // input type
-    authors?: NexusGenInputs['UserOrderByRelationAggregateInput'] | null; // UserOrderByRelationAggregateInput
-    id?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    likes?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    rating?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    status?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  PostOrderByWithRelationInput: {
+    // input type
+    authors?: NexusGenInputs['UserOrderByRelationAggregateInput'] | null // UserOrderByRelationAggregateInput
+    id?: NexusGenEnums['SortOrder'] | null // SortOrder
+    likes?: NexusGenEnums['SortOrder'] | null // SortOrder
+    rating?: NexusGenEnums['SortOrder'] | null // SortOrder
+    status?: NexusGenEnums['SortOrder'] | null // SortOrder
   }
-  PostUpdateManyMutationInput: { // input type
-    likes?: NexusGenInputs['IntFieldUpdateOperationsInput'] | null; // IntFieldUpdateOperationsInput
-    rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null; // FloatFieldUpdateOperationsInput
-    status?: NexusGenInputs['EnumPostStatusFieldUpdateOperationsInput'] | null; // EnumPostStatusFieldUpdateOperationsInput
+  PostUpdateManyMutationInput: {
+    // input type
+    likes?: NexusGenInputs['IntFieldUpdateOperationsInput'] | null // IntFieldUpdateOperationsInput
+    rating?: NexusGenInputs['FloatFieldUpdateOperationsInput'] | null // FloatFieldUpdateOperationsInput
+    status?: NexusGenInputs['EnumPostStatusFieldUpdateOperationsInput'] | null // EnumPostStatusFieldUpdateOperationsInput
   }
-  PostWhereInput: { // input type
-    AND?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
-    NOT?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
-    OR?: NexusGenInputs['PostWhereInput'][] | null; // [PostWhereInput!]
-    authors?: NexusGenInputs['UserListRelationFilter'] | null; // UserListRelationFilter
-    id?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    likes?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    rating?: NexusGenInputs['FloatFilter'] | null; // FloatFilter
-    status?: NexusGenInputs['EnumPostStatusFilter'] | null; // EnumPostStatusFilter
+  PostWhereInput: {
+    // input type
+    AND?: NexusGenInputs['PostWhereInput'][] | null // [PostWhereInput!]
+    NOT?: NexusGenInputs['PostWhereInput'][] | null // [PostWhereInput!]
+    OR?: NexusGenInputs['PostWhereInput'][] | null // [PostWhereInput!]
+    authors?: NexusGenInputs['UserListRelationFilter'] | null // UserListRelationFilter
+    id?: NexusGenInputs['IntFilter'] | null // IntFilter
+    likes?: NexusGenInputs['IntFilter'] | null // IntFilter
+    rating?: NexusGenInputs['FloatFilter'] | null // FloatFilter
+    status?: NexusGenInputs['EnumPostStatusFilter'] | null // EnumPostStatusFilter
   }
-  PostWhereUniqueInput: { // input type
-    id?: number | null; // Int
+  PostWhereUniqueInput: {
+    // input type
+    id?: number | null // Int
   }
-  StringFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    mode?: NexusGenEnums['QueryMode'] | null; // QueryMode
-    not?: NexusGenInputs['NestedStringFilter'] | null; // NestedStringFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  StringFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    mode?: NexusGenEnums['QueryMode'] | null // QueryMode
+    not?: NexusGenInputs['NestedStringFilter'] | null // NestedStringFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  StringNullableFilter: { // input type
-    contains?: string | null; // String
-    endsWith?: string | null; // String
-    equals?: string | null; // String
-    gt?: string | null; // String
-    gte?: string | null; // String
-    in?: string[] | null; // [String!]
-    lt?: string | null; // String
-    lte?: string | null; // String
-    mode?: NexusGenEnums['QueryMode'] | null; // QueryMode
-    not?: NexusGenInputs['NestedStringNullableFilter'] | null; // NestedStringNullableFilter
-    notIn?: string[] | null; // [String!]
-    startsWith?: string | null; // String
+  StringNullableFilter: {
+    // input type
+    contains?: string | null // String
+    endsWith?: string | null // String
+    equals?: string | null // String
+    gt?: string | null // String
+    gte?: string | null // String
+    in?: string[] | null // [String!]
+    lt?: string | null // String
+    lte?: string | null // String
+    mode?: NexusGenEnums['QueryMode'] | null // QueryMode
+    not?: NexusGenInputs['NestedStringNullableFilter'] | null // NestedStringNullableFilter
+    notIn?: string[] | null // [String!]
+    startsWith?: string | null // String
   }
-  UserCreateNestedManyWithoutPostsInput: { // input type
-    connect?: NexusGenInputs['UserWhereUniqueInput'][] | null; // [UserWhereUniqueInput!]
-    connectOrCreate?: NexusGenInputs['UserCreateOrConnectWithoutPostsInput'][] | null; // [UserCreateOrConnectWithoutPostsInput!]
-    create?: NexusGenInputs['UserCreateWithoutPostsInput'][] | null; // [UserCreateWithoutPostsInput!]
+  UserCreateNestedManyWithoutPostsInput: {
+    // input type
+    connect?: NexusGenInputs['UserWhereUniqueInput'][] | null // [UserWhereUniqueInput!]
+    connectOrCreate?: NexusGenInputs['UserCreateOrConnectWithoutPostsInput'][] | null // [UserCreateOrConnectWithoutPostsInput!]
+    create?: NexusGenInputs['UserCreateWithoutPostsInput'][] | null // [UserCreateWithoutPostsInput!]
   }
-  UserCreateOrConnectWithoutPostsInput: { // input type
-    create: NexusGenInputs['UserCreateWithoutPostsInput']; // UserCreateWithoutPostsInput!
-    where: NexusGenInputs['UserWhereUniqueInput']; // UserWhereUniqueInput!
+  UserCreateOrConnectWithoutPostsInput: {
+    // input type
+    create: NexusGenInputs['UserCreateWithoutPostsInput'] // UserCreateWithoutPostsInput!
+    where: NexusGenInputs['UserWhereUniqueInput'] // UserWhereUniqueInput!
   }
-  UserCreateWithoutPostsInput: { // input type
-    Bubble?: NexusGenInputs['BubbleCreateNestedOneWithoutMembersInput'] | null; // BubbleCreateNestedOneWithoutMembersInput
-    firstName: string; // String!
-    id?: string | null; // String
-    lastName: string; // String!
-    location: NexusGenInputs['LocationCreateNestedOneWithoutUserInput']; // LocationCreateNestedOneWithoutUserInput!
+  UserCreateWithoutPostsInput: {
+    // input type
+    Bubble?: NexusGenInputs['BubbleCreateNestedOneWithoutMembersInput'] | null // BubbleCreateNestedOneWithoutMembersInput
+    firstName: string // String!
+    id?: string | null // String
+    lastName: string // String!
+    location: NexusGenInputs['LocationCreateNestedOneWithoutUserInput'] // LocationCreateNestedOneWithoutUserInput!
   }
-  UserListRelationFilter: { // input type
-    every?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
-    none?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
-    some?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
+  UserListRelationFilter: {
+    // input type
+    every?: NexusGenInputs['UserWhereInput'] | null // UserWhereInput
+    none?: NexusGenInputs['UserWhereInput'] | null // UserWhereInput
+    some?: NexusGenInputs['UserWhereInput'] | null // UserWhereInput
   }
-  UserOrderByRelationAggregateInput: { // input type
-    _count?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  UserOrderByRelationAggregateInput: {
+    // input type
+    _count?: NexusGenEnums['SortOrder'] | null // SortOrder
   }
-  UserWhereInput: { // input type
-    AND?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
-    Bubble?: NexusGenInputs['BubbleWhereInput'] | null; // BubbleWhereInput
-    NOT?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
-    OR?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
-    bubbleId?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
-    firstName?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    lastName?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    location?: NexusGenInputs['LocationWhereInput'] | null; // LocationWhereInput
-    locationId?: NexusGenInputs['IntFilter'] | null; // IntFilter
-    posts?: NexusGenInputs['PostListRelationFilter'] | null; // PostListRelationFilter
+  UserWhereInput: {
+    // input type
+    AND?: NexusGenInputs['UserWhereInput'][] | null // [UserWhereInput!]
+    Bubble?: NexusGenInputs['BubbleWhereInput'] | null // BubbleWhereInput
+    NOT?: NexusGenInputs['UserWhereInput'][] | null // [UserWhereInput!]
+    OR?: NexusGenInputs['UserWhereInput'][] | null // [UserWhereInput!]
+    bubbleId?: NexusGenInputs['StringNullableFilter'] | null // StringNullableFilter
+    firstName?: NexusGenInputs['StringFilter'] | null // StringFilter
+    id?: NexusGenInputs['StringFilter'] | null // StringFilter
+    lastName?: NexusGenInputs['StringFilter'] | null // StringFilter
+    location?: NexusGenInputs['LocationWhereInput'] | null // LocationWhereInput
+    locationId?: NexusGenInputs['IntFilter'] | null // IntFilter
+    posts?: NexusGenInputs['PostListRelationFilter'] | null // PostListRelationFilter
   }
-  UserWhereUniqueInput: { // input type
-    id?: string | null; // String
+  UserWhereUniqueInput: {
+    // input type
+    id?: string | null // String
   }
 }
 
 export interface NexusGenEnums {
-  PostStatus: "DRAFT" | "PUBLISHED"
-  QueryMode: "default" | "insensitive"
-  SortOrder: "asc" | "desc"
+  PostStatus: 'DRAFT' | 'PUBLISHED'
+  QueryMode: 'default' | 'insensitive'
+  SortOrder: 'asc' | 'desc'
 }
 
 export interface NexusGenScalars {
@@ -323,103 +361,120 @@ export interface NexusGenScalars {
 }
 
 export interface NexusGenObjects {
-  AffectedRowsOutput: { // root type
-    count: number; // Int!
+  AffectedRowsOutput: {
+    // root type
+    count: number // Int!
   }
-  Bubble: { // root type
-    createdAt: NexusGenScalars['DateTime']; // DateTime!
-    id: string; // String!
+  Bubble: {
+    // root type
+    createdAt: NexusGenScalars['DateTime'] // DateTime!
+    id: string // String!
   }
-  Location: { // root type
-    city: string; // String!
-    country: string; // String!
-    id: number; // Int!
+  Location: {
+    // root type
+    city: string // String!
+    country: string // String!
+    id: number // Int!
   }
-  Mutation: {};
-  Post: { // root type
-    id: number; // Int!
-    status: NexusGenEnums['PostStatus']; // PostStatus!
+  Mutation: {}
+  Post: {
+    // root type
+    id: number // Int!
+    status: NexusGenEnums['PostStatus'] // PostStatus!
   }
-  Query: {};
-  User: { // root type
-    firstName: string; // String!
-    id: string; // String!
+  Query: {}
+  User: {
+    // root type
+    firstName: string // String!
+    id: string // String!
   }
 }
 
-export interface NexusGenInterfaces {
-}
+export interface NexusGenInterfaces {}
 
-export interface NexusGenUnions {
-}
+export interface NexusGenUnions {}
 
 export type NexusGenRootTypes = NexusGenObjects
 
 export type NexusGenAllTypes = NexusGenRootTypes & NexusGenScalars & NexusGenEnums
 
 export interface NexusGenFieldTypes {
-  AffectedRowsOutput: { // field return type
-    count: number; // Int!
+  AffectedRowsOutput: {
+    // field return type
+    count: number // Int!
   }
-  Bubble: { // field return type
-    createdAt: NexusGenScalars['DateTime']; // DateTime!
-    id: string; // String!
-    members: NexusGenRootTypes['User'][]; // [User!]!
+  Bubble: {
+    // field return type
+    createdAt: NexusGenScalars['DateTime'] // DateTime!
+    id: string // String!
+    members: NexusGenRootTypes['User'][] // [User!]!
   }
-  Location: { // field return type
-    city: string; // String!
-    country: string; // String!
-    id: number; // Int!
+  Location: {
+    // field return type
+    city: string // String!
+    country: string // String!
+    id: number // Int!
   }
-  Mutation: { // field return type
-    createOnePost: NexusGenRootTypes['Post']; // Post!
-    updateManyPost: NexusGenRootTypes['AffectedRowsOutput']; // AffectedRowsOutput!
+  Mutation: {
+    // field return type
+    createOnePost: NexusGenRootTypes['Post'] // Post!
+    updateManyPost: NexusGenRootTypes['AffectedRowsOutput'] // AffectedRowsOutput!
   }
-  Post: { // field return type
-    authors: NexusGenRootTypes['User'][]; // [User!]!
-    id: number; // Int!
-    status: NexusGenEnums['PostStatus']; // PostStatus!
+  Post: {
+    // field return type
+    authors: NexusGenRootTypes['User'][] // [User!]!
+    id: number // Int!
+    status: NexusGenEnums['PostStatus'] // PostStatus!
   }
-  Query: { // field return type
-    user: NexusGenRootTypes['User'] | null; // User
-    users: NexusGenRootTypes['User'][]; // [User!]!
+  Query: {
+    // field return type
+    user: NexusGenRootTypes['User'] | null // User
+    users: NexusGenRootTypes['User'][] // [User!]!
   }
-  User: { // field return type
-    firstName: string; // String!
-    id: string; // String!
-    location: NexusGenRootTypes['Location']; // Location!
-    posts: NexusGenRootTypes['Post'][]; // [Post!]!
+  User: {
+    // field return type
+    firstName: string // String!
+    id: string // String!
+    location: NexusGenRootTypes['Location'] // Location!
+    posts: NexusGenRootTypes['Post'][] // [Post!]!
   }
 }
 
 export interface NexusGenFieldTypeNames {
-  AffectedRowsOutput: { // field return type name
+  AffectedRowsOutput: {
+    // field return type name
     count: 'Int'
   }
-  Bubble: { // field return type name
+  Bubble: {
+    // field return type name
     createdAt: 'DateTime'
     id: 'String'
     members: 'User'
   }
-  Location: { // field return type name
+  Location: {
+    // field return type name
     city: 'String'
     country: 'String'
     id: 'Int'
   }
-  Mutation: { // field return type name
+  Mutation: {
+    // field return type name
     createOnePost: 'Post'
     updateManyPost: 'AffectedRowsOutput'
   }
-  Post: { // field return type name
+  Post: {
+    // field return type name
     authors: 'User'
     id: 'Int'
     status: 'PostStatus'
   }
-  Query: { // field return type name
+  Query: {
+    // field return type name
     user: 'User'
     users: 'User'
   }
-  User: { // field return type name
+  User: {
+    // field return type name
     firstName: 'String'
     id: 'String'
     location: 'Location'
@@ -429,65 +484,69 @@ export interface NexusGenFieldTypeNames {
 
 export interface NexusGenArgTypes {
   Bubble: {
-    members: { // args
-      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
-      orderBy?: NexusGenInputs['BubbleMembersOrderByInput'][] | null; // [BubbleMembersOrderByInput!]
-      where?: NexusGenInputs['BubbleMembersWhereInput'] | null; // BubbleMembersWhereInput
+    members: {
+      // args
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null // UserWhereUniqueInput
+      orderBy?: NexusGenInputs['BubbleMembersOrderByInput'][] | null // [BubbleMembersOrderByInput!]
+      where?: NexusGenInputs['BubbleMembersWhereInput'] | null // BubbleMembersWhereInput
     }
   }
   Mutation: {
-    createOnePost: { // args
-      data: NexusGenInputs['PostCreateInput']; // PostCreateInput!
+    createOnePost: {
+      // args
+      data: NexusGenInputs['PostCreateInput'] // PostCreateInput!
     }
-    updateManyPost: { // args
-      data: NexusGenInputs['PostUpdateManyMutationInput']; // PostUpdateManyMutationInput!
-      where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
+    updateManyPost: {
+      // args
+      data: NexusGenInputs['PostUpdateManyMutationInput'] // PostUpdateManyMutationInput!
+      where?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
     }
   }
   Query: {
-    user: { // args
-      where: NexusGenInputs['UserWhereUniqueInput']; // UserWhereUniqueInput!
+    user: {
+      // args
+      where: NexusGenInputs['UserWhereUniqueInput'] // UserWhereUniqueInput!
     }
-    users: { // args
-      after?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
-      before?: NexusGenInputs['UserWhereUniqueInput'] | null; // UserWhereUniqueInput
-      first?: number | null; // Int
-      last?: number | null; // Int
+    users: {
+      // args
+      after?: NexusGenInputs['UserWhereUniqueInput'] | null // UserWhereUniqueInput
+      before?: NexusGenInputs['UserWhereUniqueInput'] | null // UserWhereUniqueInput
+      first?: number | null // Int
+      last?: number | null // Int
     }
   }
   User: {
-    posts: { // args
-      after?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
-      before?: NexusGenInputs['PostWhereUniqueInput'] | null; // PostWhereUniqueInput
-      first?: number | null; // Int
-      last?: number | null; // Int
-      orderBy?: NexusGenInputs['PostOrderByWithRelationInput'][] | null; // [PostOrderByWithRelationInput!]
-      where?: NexusGenInputs['PostWhereInput'] | null; // PostWhereInput
+    posts: {
+      // args
+      after?: NexusGenInputs['PostWhereUniqueInput'] | null // PostWhereUniqueInput
+      before?: NexusGenInputs['PostWhereUniqueInput'] | null // PostWhereUniqueInput
+      first?: number | null // Int
+      last?: number | null // Int
+      orderBy?: NexusGenInputs['PostOrderByWithRelationInput'][] | null // [PostOrderByWithRelationInput!]
+      where?: NexusGenInputs['PostWhereInput'] | null // PostWhereInput
     }
   }
 }
 
-export interface NexusGenAbstractTypeMembers {
-}
+export interface NexusGenAbstractTypeMembers {}
 
-export interface NexusGenTypeInterfaces {
-}
+export interface NexusGenTypeInterfaces {}
 
-export type NexusGenObjectNames = keyof NexusGenObjects;
+export type NexusGenObjectNames = keyof NexusGenObjects
 
-export type NexusGenInputNames = keyof NexusGenInputs;
+export type NexusGenInputNames = keyof NexusGenInputs
 
-export type NexusGenEnumNames = keyof NexusGenEnums;
+export type NexusGenEnumNames = keyof NexusGenEnums
 
-export type NexusGenInterfaceNames = never;
+export type NexusGenInterfaceNames = never
 
-export type NexusGenScalarNames = keyof NexusGenScalars;
+export type NexusGenScalarNames = keyof NexusGenScalars
 
-export type NexusGenUnionNames = never;
+export type NexusGenUnionNames = never
 
-export type NexusGenObjectsUsingAbstractStrategyIsTypeOf = never;
+export type NexusGenObjectsUsingAbstractStrategyIsTypeOf = never
 
-export type NexusGenAbstractsUsingStrategyResolveType = never;
+export type NexusGenAbstractsUsingStrategyResolveType = never
 
 export type NexusGenFeaturesConfig = {
   abstractTypeStrategies: {
@@ -498,43 +557,41 @@ export type NexusGenFeaturesConfig = {
 }
 
 export interface NexusGenTypes {
-  context: any;
-  inputTypes: NexusGenInputs;
-  rootTypes: NexusGenRootTypes;
-  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars;
-  argTypes: NexusGenArgTypes;
-  fieldTypes: NexusGenFieldTypes;
-  fieldTypeNames: NexusGenFieldTypeNames;
-  allTypes: NexusGenAllTypes;
-  typeInterfaces: NexusGenTypeInterfaces;
-  objectNames: NexusGenObjectNames;
-  inputNames: NexusGenInputNames;
-  enumNames: NexusGenEnumNames;
-  interfaceNames: NexusGenInterfaceNames;
-  scalarNames: NexusGenScalarNames;
-  unionNames: NexusGenUnionNames;
-  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames'];
-  allOutputTypes: NexusGenTypes['objectNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['unionNames'] | NexusGenTypes['interfaceNames'] | NexusGenTypes['scalarNames'];
+  context: any
+  inputTypes: NexusGenInputs
+  rootTypes: NexusGenRootTypes
+  inputTypeShapes: NexusGenInputs & NexusGenEnums & NexusGenScalars
+  argTypes: NexusGenArgTypes
+  fieldTypes: NexusGenFieldTypes
+  fieldTypeNames: NexusGenFieldTypeNames
+  allTypes: NexusGenAllTypes
+  typeInterfaces: NexusGenTypeInterfaces
+  objectNames: NexusGenObjectNames
+  inputNames: NexusGenInputNames
+  enumNames: NexusGenEnumNames
+  interfaceNames: NexusGenInterfaceNames
+  scalarNames: NexusGenScalarNames
+  unionNames: NexusGenUnionNames
+  allInputTypes: NexusGenTypes['inputNames'] | NexusGenTypes['enumNames'] | NexusGenTypes['scalarNames']
+  allOutputTypes:
+    | NexusGenTypes['objectNames']
+    | NexusGenTypes['enumNames']
+    | NexusGenTypes['unionNames']
+    | NexusGenTypes['interfaceNames']
+    | NexusGenTypes['scalarNames']
   allNamedTypes: NexusGenTypes['allInputTypes'] | NexusGenTypes['allOutputTypes']
-  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames'];
-  abstractTypeMembers: NexusGenAbstractTypeMembers;
-  objectsUsingAbstractStrategyIsTypeOf: NexusGenObjectsUsingAbstractStrategyIsTypeOf;
-  abstractsUsingStrategyResolveType: NexusGenAbstractsUsingStrategyResolveType;
-  features: NexusGenFeaturesConfig;
+  abstractTypes: NexusGenTypes['interfaceNames'] | NexusGenTypes['unionNames']
+  abstractTypeMembers: NexusGenAbstractTypeMembers
+  objectsUsingAbstractStrategyIsTypeOf: NexusGenObjectsUsingAbstractStrategyIsTypeOf
+  abstractsUsingStrategyResolveType: NexusGenAbstractsUsingStrategyResolveType
+  features: NexusGenFeaturesConfig
 }
 
-
 declare global {
-  interface NexusGenPluginTypeConfig<TypeName extends string> {
-  }
-  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
-  }
-  interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
-  }
-  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {
-  }
-  interface NexusGenPluginSchemaConfig {
-  }
-  interface NexusGenPluginArgConfig {
-  }
+  interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
+  interface NexusGenPluginSchemaConfig {}
+  interface NexusGenPluginArgConfig {}
 }

--- a/tests/__utils.ts
+++ b/tests/__utils.ts
@@ -27,7 +27,7 @@ export async function getDmmf(datamodel: string, options?: TransformOptions) {
   // dumpToFile(originalDmmf, 'document.getDmmf.original');
   const clientDmmf = PrismaClientGenerator.externalToInternalDmmf(originalDmmf)
   // dumpToFile(clientDmmf, 'document.getDmmf.client');
-  return new DmmfDocument(transform(clientDmmf, {...options, dmmfDocumentIncludesSchema: true}))
+  return new DmmfDocument(transform(clientDmmf, { ...options, dmmfDocumentIncludesSchema: true }))
 }
 
 export async function getPinnedDmmfFromSchemaPath(datamodelPath: string) {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -72,9 +72,9 @@ it('integrates together', async () => {
         modules: [
           {
             module: require.resolve('@prisma/client/index.d.ts'),
-            alias: "prisma",
-          }
-        ]
+            alias: 'prisma',
+          },
+        ],
       },
       outputs: {
         typegen: fs.path(`generated/nexus-typegen.d.ts`),

--- a/tests/runtime/custom-resolver.test.ts
+++ b/tests/runtime/custom-resolver.test.ts
@@ -34,7 +34,7 @@ it('supports custom resolver for t.crud', async () => {
           originalResolve: GraphQLFieldResolver<any, any, any>
         ) => {
           before()
-          const res = await originalResolve(root, args, ctx, info) as unknown[];
+          const res = (await originalResolve(root, args, ctx, info)) as unknown[]
           after()
           return [...res, { id: 2 }]
         },

--- a/tests/runtime/scalars.test.ts
+++ b/tests/runtime/scalars.test.ts
@@ -54,7 +54,7 @@ it('supports custom scalars as output type', async () => {
       }
     }`)
   } catch (rawE) {
-    const e = rawE as Error;
+    const e = rawE as Error
     // console.log(`caught error: ${JSON.stringify(rawE, null, 2)}`);
 
     // exception propagation doesn't seem to work as expected.

--- a/tests/schema/__snapshots__/ordering.test.ts.snap
+++ b/tests/schema/__snapshots__/ordering.test.ts.snap
@@ -1,5 +1,182 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`finds correct ordering types if fullTextSearch preview feature is enabled: schema 1`] = `
+"type Foo {
+  id: Int!
+  a: String!
+  bars(orderBy: [BarOrderByWithRelationAndSearchRelevanceInput!], first: Int, last: Int, before: BarWhereUniqueInput, after: BarWhereUniqueInput): [Bar!]!
+}
+
+type Bar {
+  id: Int!
+  foo: Foo
+}
+
+type Query {
+  foos(orderBy: [FooOrderByWithRelationAndSearchRelevanceInput!], first: Int, last: Int, before: FooWhereUniqueInput, after: FooWhereUniqueInput): [Foo!]!
+}
+
+input BarOrderByWithRelationAndSearchRelevanceInput {
+  id: SortOrder
+  fooId: SortOrder
+  foo: FooOrderByWithRelationAndSearchRelevanceInput
+}
+
+input BarWhereUniqueInput {
+  id: Int
+}
+
+input FooOrderByWithRelationAndSearchRelevanceInput {
+  id: SortOrder
+  a: SortOrder
+  bars: BarOrderByRelationAggregateInput
+  _relevance: FooOrderByRelevanceInput
+}
+
+input FooWhereUniqueInput {
+  id: Int
+}
+
+enum SortOrder {
+  asc
+  desc
+}
+
+input BarOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
+input FooOrderByRelevanceInput {
+  fields: FooOrderByRelevanceFieldEnum!
+  sort: SortOrder!
+  search: String!
+}
+
+enum FooOrderByRelevanceFieldEnum {
+  a
+}"
+`;
+
+exports[`finds correct ordering types if fullTextSearch preview feature is enabled: typegen 1`] = `
+"import * as Typegen from '@morgothulhu/nexus-plugin-prisma/typegen'
+import * as Prisma from '@prisma/client';
+
+// Pagination type
+type Pagination = {
+    first?: boolean
+    last?: boolean
+    before?: boolean
+    after?: boolean
+}
+
+// Prisma custom scalar names
+type CustomScalars = 'No custom scalars are used in your Prisma Schema.'
+
+// Prisma model type definitions
+interface PrismaModels {
+  Foo: Prisma.Foo
+  Bar: Prisma.Bar
+}
+
+// Prisma input types metadata
+interface NexusPrismaInputs {
+  Query: {
+    foos: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'a' | 'bars'
+      ordering: 'id' | 'a' | 'bars' | '_relevance'
+    }
+    groupByFoo: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'a' | 'bars'
+      ordering: 'id' | 'a' | '_count' | '_avg' | '_max' | '_min' | '_sum'
+    }
+    bars: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'fooId' | 'foo'
+      ordering: 'id' | 'fooId' | 'foo'
+    }
+    groupByBar: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'fooId' | 'foo'
+      ordering: 'id' | 'fooId' | '_count' | '_avg' | '_max' | '_min' | '_sum'
+    }
+  },
+  Foo: {
+    bars: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'fooId' | 'foo'
+      ordering: 'id' | 'fooId' | 'foo'
+    }
+  }
+  Bar: {
+
+  }
+}
+
+// Prisma output types metadata
+interface NexusPrismaOutputs {
+  Query: {
+    aggregateFoo: 'AggregateFoo'
+    foos: 'Foo'
+    foo: 'Foo'
+    groupByFoo: 'FooGroupByOutputType'
+    aggregateBar: 'AggregateBar'
+    bars: 'Bar'
+    bar: 'Bar'
+    groupByBar: 'BarGroupByOutputType'
+  },
+  Mutation: {
+    createOneFoo: 'Foo'
+    createManyFoo: 'AffectedRowsOutput'
+    deleteOneFoo: 'Foo'
+    deleteManyFoo: 'AffectedRowsOutput'
+    updateOneFoo: 'Foo'
+    updateManyFoo: 'AffectedRowsOutput'
+    upsertOneFoo: 'Foo'
+    createOneBar: 'Bar'
+    createManyBar: 'AffectedRowsOutput'
+    deleteOneBar: 'Bar'
+    deleteManyBar: 'AffectedRowsOutput'
+    updateOneBar: 'Bar'
+    updateManyBar: 'AffectedRowsOutput'
+    upsertOneBar: 'Bar'
+  },
+  Foo: {
+    id: 'Int'
+    a: 'String'
+    bars: 'Bar'
+  }
+  Bar: {
+    id: 'Int'
+    fooId: 'Int'
+    foo: 'Foo'
+  }
+}
+
+// Helper to gather all methods relative to a model
+interface NexusPrismaMethods {
+  Foo: Typegen.NexusPrismaFields<'Foo'>
+  Bar: Typegen.NexusPrismaFields<'Bar'>
+  Query: Typegen.NexusPrismaFields<'Query'>
+  Mutation: Typegen.NexusPrismaFields<'Mutation'>
+}
+
+interface NexusPrismaGenTypes {
+  inputs: NexusPrismaInputs
+  outputs: NexusPrismaOutputs
+  methods: NexusPrismaMethods
+  models: PrismaModels
+  pagination: Pagination
+  scalars: CustomScalars
+}
+
+declare global {
+  interface NexusPrismaGen extends NexusPrismaGenTypes {}
+
+  type NexusPrisma<
+    TypeName extends string,
+    ModelOrCrud extends 'model' | 'crud'
+  > = Typegen.GetNexusPrisma<TypeName, ModelOrCrud>;
+}
+  "
+`;
+
 exports[`orderby fields can be allow-listed: schema 1`] = `
 "type Foo {
   id: Int!

--- a/tests/schema/filtering-ordering.test.ts
+++ b/tests/schema/filtering-ordering.test.ts
@@ -29,7 +29,11 @@ it('in dev stage, removes filtering or ordering entirely if no arg or wrong args
     }),
   ]
 
-  const { schemaString: schema, $output, typegen } = await mockConsoleLog(async () => {
+  const {
+    schemaString: schema,
+    $output,
+    typegen,
+  } = await mockConsoleLog(async () => {
     return generateSchemaAndTypes(datamodel, typeDefs)
   })
 
@@ -72,7 +76,7 @@ it('in prod stage, throw error if no arg or wrong args are passed', async () => 
     expect(schema).toMatchSnapshot('schema')
     expect(typegen).toMatchSnapshot('typegen')
   } catch (rawE) {
-    const e = rawE as Error;
+    const e = rawE as Error
     expect(e.message).toMatchSnapshot('output')
   }
 })

--- a/tests/schema/ordering.test.ts
+++ b/tests/schema/ordering.test.ts
@@ -29,3 +29,59 @@ it('orderby fields can be allow-listed', async () => {
   expect(schema).toMatchSnapshot('schema')
   expect(typegen).toMatchSnapshot('typegen')
 })
+
+it('finds correct ordering types if fullTextSearch preview feature is enabled', async () => {
+  const datamodel = `
+    generator prisma_client {
+      provider = "prisma-client-js"
+      output   = "../../node_modules/.prisma/client"
+      previewFeatures = ["fullTextSearch"]
+    }
+
+    datasource db {
+      provider = "postgres"
+      url      = env("DB_URL")
+    }
+
+    model Foo {
+      id    Int @id @default(autoincrement())
+      a     String
+      bars  Bar[]
+    }
+
+    model Bar {
+      id    Int @id @default(autoincrement())
+      fooId Int?
+      foo   Foo? @relation(fields: [fooId], references: [id])
+    }
+  `
+
+  const { schemaString: schema, typegen } = await generateSchemaAndTypes(datamodel, [
+    objectType({
+      name: 'Foo',
+      definition(t: any) {
+        t.model.id()
+        t.model.a()
+        t.model.bars({ ordering: true })
+      },
+    }),
+    objectType({
+      name: 'Bar',
+      definition(t: any) {
+        t.model.id()
+        t.model.foo()
+      },
+    }),
+    objectType({
+      name: 'Query',
+      definition(t: any) {
+        t.crud.foos({
+          ordering: true,
+        })
+      },
+    }),
+  ])
+
+  expect(schema).toMatchSnapshot('schema')
+  expect(typegen).toMatchSnapshot('typegen')
+})


### PR DESCRIPTION
If the preview feature `fullTextSearch` is enabled and supported by the provider (`postgresql` or `mysql`), then the `orderBy` argument typenames change from `*OrderByWithRelationInput` to `*OrderByWithRelationAndSearchRelevanceInput`. Added this variation so the builder will find the correct typename and not throw.

Also added a simple schema test to check this change actually works. Testing this in the runtime is not currently possible, as the feature is not supported for the `sqlite` provider used. However, for future runtime testing of other preview features I added the option to pass an array to the runtime test context setup function:

```ts
const ctx = createRuntimeTestContext()
const { graphqlClient, dbClient } = await ctx.setup({
  datamodel,
  types: [...],
  previewFeatures: [...]
})
```

The array contents will be added to the schema generator block.

Finally, I ran `prettier` as set up in the `package.json`, which accounts for the majority of changes here -- the rules come straight from `@prisma-labs/prettier-config`.